### PR TITLE
Fix to create a firewall rule with the specific source IP

### DIFF
--- a/libcloud/compute/drivers/dimensiondata.py
+++ b/libcloud/compute/drivers/dimensiondata.py
@@ -1135,7 +1135,8 @@ class DimensionDataNodeDriver(NodeDriver):
             source_ip.set('address', 'ANY')
         else:
             source_ip.set('address', rule.source.ip_address)
-            source_ip.set('prefixSize', str(rule.source.ip_prefix_size))
+            if rule.source.ip_prefix_size is not None:                
+                source_ip.set('prefixSize', str(rule.source.ip_prefix_size))
             if rule.source.port_begin is not None:
                 source_port = ET.SubElement(source, 'port')
                 source_port.set('begin', rule.source.port_begin)

--- a/libcloud/test/compute/fixtures/dimensiondata/caas_2_1_8a8f6abc_2745_4d8a_9cbc_8dabe5a7d0e4_network_firewallRule.xml
+++ b/libcloud/test/compute/fixtures/dimensiondata/caas_2_1_8a8f6abc_2745_4d8a_9cbc_8dabe5a7d0e4_network_firewallRule.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<firewallRules xmlns="urn:didata.com:api:cloud:types" pageNumber="1" pageCount="13" totalCount="13" pageSize="50">
+<firewallRules xmlns="urn:didata.com:api:cloud:types" pageNumber="1" pageCount="13" totalCount="13" pageSize="50">     
     <firewallRule id="756cba02-b0bc-48f4-aea5-9445870b6148" datacenterId="NA9" ruleType="DEFAULT_RULE">
         <networkDomainId>b30c224c-c95b-4cd9-bb8b-bfdfb5486abf</networkDomainId>
         <name>CCDEFAULT.BlockOutboundMailIPv4</name>
@@ -203,6 +203,21 @@
         <destination>
             <ip address="2607:f480:111:1336:6503:544c:74a6:3a28"/>
             <port begin="9443"/>
+        </destination>
+        <enabled>true</enabled>
+        <state>NORMAL</state>
+    </firewallRule>
+    <firewallRule id="b976e0e6-4fb2-4f3e-a016-652e02d211b4" datacenterId="NA9" ruleType="CLIENT_RULE">
+        <networkDomainId>b30c224c-c95b-4cd9-bb8b-bfdfb5486abf</networkDomainId>
+        <name>SpecificSourceIP</name>
+        <action>ACCEPT_DECISIVELY</action>
+        <ipVersion>IPV6</ipVersion>
+        <protocol>TCP</protocol>
+        <source>
+            <ip address="2607:f480:111:1336:6503:544c:74a6:3a28"/>            
+        </source>
+        <destination>
+            <ip address="ANY"/>
         </destination>
         <enabled>true</enabled>
         <state>NORMAL</state>

--- a/libcloud/test/compute/test_dimensiondata.py
+++ b/libcloud/test/compute/test_dimensiondata.py
@@ -33,6 +33,7 @@ from libcloud.test.file_fixtures import ComputeFileFixtures
 from libcloud.test.secrets import DIMENSIONDATA_PARAMS
 
 
+
 class DimensionDataTests(unittest.TestCase, TestCaseMixin):
 
     def setUp(self):
@@ -448,8 +449,16 @@ class DimensionDataTests(unittest.TestCase, TestCaseMixin):
 
     def test_ex_create_firewall_rule(self):
         net = self.driver.ex_get_network_domain('8cdfd607-f429-4df6-9352-162cfc0891be')
-        rules = self.driver.ex_list_firewall_rules(net)
+        rules = self.driver.ex_list_firewall_rules(net)        
         rule = self.driver.ex_create_firewall_rule(net, rules[0], 'FIRST')
+        self.assertEqual(rule.id, 'd0a20f59-77b9-4f28-a63b-e58496b73a6c')
+        
+    def test_ex_create_firewall_rule_with_specific_source_ip(self):
+        net = self.driver.ex_get_network_domain('8cdfd607-f429-4df6-9352-162cfc0891be')
+        rules = self.driver.ex_list_firewall_rules(net)
+        specific_source_ip_rule = list(filter(lambda x: x.name == 'SpecificSourceIP', 
+                                              rules))[0]        
+        rule = self.driver.ex_create_firewall_rule(net, specific_source_ip_rule, 'FIRST')
         self.assertEqual(rule.id, 'd0a20f59-77b9-4f28-a63b-e58496b73a6c')
 
     def test_ex_get_firewall_rule(self):


### PR DESCRIPTION
Added a if condition to check the source ip prefix size is not none before passing the value to the API which will enable us to create a firewall rule with the specific source ip

```
if rule.source.ip_prefix_size is not None: 
 source_ip.set('prefixSize', str(rule.source.ip_prefix_size))
```
