### PR TITLE
reordered the element creation to fix the issue when pool member is c…

### DIFF
--- a/libcloud/loadbalancer/drivers/dimensiondata.py
+++ b/libcloud/loadbalancer/drivers/dimensiondata.py
@@ -340,9 +340,9 @@ class DimensionDataLBDriver(Driver):
         create_pool_m = ET.Element('addPoolMember', {'xmlns': TYPES_URN})
         ET.SubElement(create_pool_m, "poolId").text = pool.id
         ET.SubElement(create_pool_m, "nodeId").text = node.id
-        ET.SubElement(create_pool_m, "status").text = 'ENABLED'
         if port is not None:
             ET.SubElement(create_pool_m, "port").text = str(port)
+        ET.SubElement(create_pool_m, "status").text = 'ENABLED'
 
         response = self.connection.request_with_orgId_api_2(
             'networkDomainVip/addPoolMember',


### PR DESCRIPTION
when the pool member is created with the port the CAAS API raise the exception as below

libcloud.common.dimensiondata.DimensionDataAPIException: INVALID_INPUT_DATA: lineNumber: 1; columnNumber: 191; cvc-complex-type.2.4.d: Invalid content was found starting with element 'port'. No child element is expected at this point.

To fix the above issue, I have reordered the element creation.
