### PR TITLE
if address_list is not none, then the ip element will be none and cannot do get attribute on None Type

### DIFF
--- a/libcloud/compute/drivers/dimensiondata.py
+++ b/libcloud/compute/drivers/dimensiondata.py
@@ -2063,8 +2063,12 @@ class DimensionDataNodeDriver(NodeDriver):
             status=findtext(element, 'state', TYPES_URN))
 
     def _to_firewall_address(self, element):
+        ip = element.find(fixxpath('ip', TYPES_URN))
+        port = element.find(fixxpath('port', TYPES_URN))
+        port_list = element.find(fixxpath('portList', TYPES_URN))
+        address_list = element.find(fixxpath('ipAddressList', TYPES_URN))
         if address_list is None:
-            return DimensionDataFirewallAddress(
+            return DimensionDataFirewallAddress (
                 any_ip=ip.get('address') == 'ANY',
                 ip_address=ip.get('address'),
                 ip_prefix_size=ip.get('prefixSize'),

--- a/libcloud/compute/drivers/dimensiondata.py
+++ b/libcloud/compute/drivers/dimensiondata.py
@@ -2063,21 +2063,30 @@ class DimensionDataNodeDriver(NodeDriver):
             status=findtext(element, 'state', TYPES_URN))
 
     def _to_firewall_address(self, element):
-        ip = element.find(fixxpath('ip', TYPES_URN))
-        port = element.find(fixxpath('port', TYPES_URN))
-        port_list = element.find(fixxpath('portList', TYPES_URN))
-        address_list = element.find(fixxpath('ipAddressList', TYPES_URN))
-        return DimensionDataFirewallAddress(
-            any_ip=ip.get('address') == 'ANY',
-            ip_address=ip.get('address'),
-            ip_prefix_size=ip.get('prefixSize'),
-            port_begin=port.get('begin') if port is not None else None,
-            port_end=port.get('end') if port is not None else None,
-            port_list_id=port_list.get('id', None)
-            if port_list is not None else None,
-            address_list_id=address_list.get('id')
-            if address_list is not None else None
-        )
+        if address_list is None:
+            return DimensionDataFirewallAddress(
+                any_ip=ip.get('address') == 'ANY',
+                ip_address=ip.get('address'),
+                ip_prefix_size=ip.get('prefixSize'),
+                port_begin=port.get('begin') if port is not None else None,
+                port_end=port.get('end') if port is not None else None,
+                port_list_id=port_list.get('id', None)
+                if port_list is not None else None,
+                address_list_id=address_list.get('id')
+                if address_list is not None else None
+                )
+        else:
+            return DimensionDataFirewallAddress(
+                any_ip = False,
+                ip_address= None,
+                ip_prefix_size = None,
+                port_begin = None,
+                port_end = None,
+                port_list_id=port_list.get('id', None)
+                if port_list is not None else None,
+                address_list_id=address_list.get('id')
+                if address_list is not None else None
+                )
 
     def _to_ip_blocks(self, object):
         blocks = []


### PR DESCRIPTION
fix when any of the firewall rules in the network domain has a address_list, it will avoid the error 

 _to_firewall_address
any_ip=ip.get('address') == 'ANY'
AttributeError: 'NoneType' object has no attribute 'get'
